### PR TITLE
Add new pip install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ The script [`lstm_crf/main.py`](https://github.com/guillaumegenthial/tf_ner/blob
 You need __python3__ -- If you haven't switched yet, do it.
 
 You need to install [`tf_metrics` ](https://github.com/guillaumegenthial/tf_metrics) (multi-class precision, recall and f1 metrics for Tensorflow).
-
+```
+pip install git+https://github.com/guillaumegenthial/tf_metrics.git
+```
+OR
 ```
 git clone https://github.com/guillaumegenthial/tf_metrics.git
 cd tf_metrics


### PR DESCRIPTION
You can install tf_metrics a bit simpler with pip, so this just updates the readme to add the better method.