### PR TITLE
Enforce UTF-8 Encoding

### DIFF
--- a/data/example/build_glove.py
+++ b/data/example/build_glove.py
@@ -14,7 +14,7 @@ import numpy as np
 
 if __name__ == '__main__':
     # Load vocab
-    with Path('vocab.words.txt').open() as f:
+    with Path('vocab.words.txt').open(encoding="utf8") as f:
         word_to_idx = {line.strip(): idx for idx, line in enumerate(f)}
     size_vocab = len(word_to_idx)
 
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     # Get relevant glove vectors
     found = 0
     print('Reading GloVe file (may take a while)')
-    with Path('glove.840B.300d.txt').open() as f:
+    with Path('glove.840B.300d.txt').open(encoding="utf8") as f:
         for line_idx, line in enumerate(f):
             if line_idx % 100000 == 0:
                 print('- At line {}'.format(line_idx))


### PR DESCRIPTION
Without proper encoding, I've got the following error:

```
Reading GloVe file (may take a while)
- At line 0
Traceback (most recent call last):
  File ".\build_glove.py", line 28, in <module>
    for line_idx, line in enumerate(f):
  File "C:\ProgramData\Anaconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 962: character maps to <undefined>
```